### PR TITLE
Remove gemini-is-starting and do not start gemini process by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,21 @@ This package will not be uploaded to melpa, thanks for your understanding.
 (add-to-list 'load-path "<path-to-gemini>")
 (require 'gemini)
 ```
+3. You need to have your Google Gemini API token ready. You can get an API key via [Google AI Studio](https://makersuite.google.com/app/apikey).
+```
+(setq gemini-api-token "your api token")
+```
+4. Start gemini process
+```
+(gemini-start-process)
+```
 
 Et voilà 🎉
 
 ## Usage
 
-1. You need to have your Google Gemini API token ready. You can get an API key via [Google AI Studio](https://makersuite.google.com/app/apikey).
-```
-(setq gemini-api-token "your api token")
-```
-2. Install Python dependencies: `pip install epc sexpdata google-generativeai`
-3. Install [markdown-mode](https://github.com/jrblevin/markdown-mode)
+1. Install Python dependencies: `pip install epc sexpdata google-generativeai`
+2. Install [markdown-mode](https://github.com/jrblevin/markdown-mode)
 
 *Note*: Gemini currently has limited language support, so some commands cannot be implemented temporarily.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,17 +17,21 @@
 (add-to-list 'load-path "<path-to-gemini>")
 (require 'gemini)
 ```
+3. 你需要准备好你的 Google Gemini API 令牌。你可以通过 [Google AI Studio](https://makersuite.google.com/app/apikey) 获取一个 API 密钥。
+```
+(setq gemini-api-token "your api token")
+```
+4. 启动Gemini进程
+```
+(gemini-start-process)
+```
 
 大功告成🎉
 
 ## 用法
 
-1. 你需要准备好你的 Google Gemini API 令牌。你可以通过 [Google AI Studio](https://makersuite.google.com/app/apikey) 获取一个 API 密钥。
-```
-(setq gemini-api-token "your api token")
-```
-2. 安装 Python 依赖项：`pip install epc sexpdata google-generativeai`
-3. 安装 [markdown-mode](https://github.com/jrblevin/markdown-mode)
+1. 安装 Python 依赖项：`pip install epc sexpdata google-generativeai`
+2. 安装 [markdown-mode](https://github.com/jrblevin/markdown-mode)
 
 *声明* : Gemini 目前支持的语言有限，故部分命令暂时无法实现
 

--- a/gemini.el
+++ b/gemini.el
@@ -201,20 +201,15 @@ Then Gemini will start by gdb, please send new issue with `*gemini*' buffer cont
 	   (gemini-epc-call-deferred gemini-epc-process (read method) args))
     (gemini-start-process)))
 
-(defvar gemini-is-starting nil)
-
 (defun gemini-restart-process ()
   "Stop and restart Gemini process."
   (interactive)
-  (setq gemini-is-starting nil)
-
   (gemini-kill-process)
   (gemini-start-process)
   (message "[Gemini] Process restarted."))
 
 (defun gemini-start-process ()
   "Start Gemini process if it isn't started."
-  (setq gemini-is-starting t)
   (unless (gemini-epc-live-p gemini-epc-process)
     ;; start epc server and set `gemini-server-port'
     (gemini--start-epc-server)
@@ -279,7 +274,6 @@ Then Gemini will start by gdb, please send new issue with `*gemini*' buffer cont
                             :connection (gemini-epc-connect "localhost" gemini-epc-port)
                             ))
   (gemini-epc-init-epc-layer gemini-epc-process)
-  (setq gemini-is-starting nil)
 
   (message "[Gemini] Process started successfully."))
 
@@ -553,10 +547,6 @@ Then Gemini will start by gdb, please send new issue with `*gemini*' buffer cont
     (goto-char gemini-draft--begin)
     (insert draft))
   (setq gemini-draft--end (+ gemini-draft--begin (length draft))))
-
-(unless gemini-is-starting
-  (gemini-start-process))
-
 
 (provide 'gemini)
 ;;; gemini.el ends here


### PR DESCRIPTION
1. Do not start gemini process. Leave it to user to start it. For example, user need to configure the token before start the process. 
2. Remove `gemini-is-starting`